### PR TITLE
Correcting CKA similarity to output distance by subtracting 1

### DIFF
--- a/anatome/similarity.py
+++ b/anatome/similarity.py
@@ -200,7 +200,7 @@ def linear_cka_distance(x: Tensor,
         dot_prod = _debiased_dot_product_similarity(dot_prod, sum_row_x, sum_row_y, sq_norm_x, sq_norm_y, size)
         norm_x = _debiased_dot_product_similarity(norm_x.pow_(2), sum_row_x, sum_row_y, sq_norm_x, sq_norm_y, size)
         norm_y = _debiased_dot_product_similarity(norm_y.pow_(2), sum_row_x, sum_row_y, sq_norm_x, sq_norm_y, size)
-    return dot_prod / (norm_x * norm_y)
+    return 1 - dot_prod / (norm_x * norm_y)
 
 
 class SimilarityHook(object):


### PR DESCRIPTION
corrected what seems to be that anatome is returning similarity when the function name is distance.

Including the table from the original CKA paper to ensure my suggestion is correct indeed:

<img width="839" alt="Screen Shot 2021-02-02 at 4 52 02 PM" src="https://user-images.githubusercontent.com/1855278/106780460-a42db900-660d-11eb-982f-e1800394d4c3.png">

paper link: http://proceedings.mlr.press/v97/kornblith19a.html